### PR TITLE
Ds1 refactor: removed npcIndexes field+fixed SetNumberOfWalls bug

### DIFF
--- a/d2common/d2fileformats/d2ds1/ds1.go
+++ b/d2common/d2fileformats/d2ds1/ds1.go
@@ -765,7 +765,8 @@ func (ds1 *DS1) loadSubstitutions(br *d2datautils.StreamReader) error {
 	return err
 }
 
-func (ds1 *DS1) setupStreamLayerTypes() []d2enum.LayerStreamType {
+// GetStreamLayerTypes returns layers used in ds1
+func (ds1 *DS1) GetStreamLayerTypes() []d2enum.LayerStreamType {
 	var layerStream []d2enum.LayerStreamType
 
 	if ds1.version < v4 {
@@ -900,7 +901,7 @@ func (ds1 *DS1) loadLayerStreams(br *d2datautils.StreamReader) error {
 		0x0F, 0x10, 0x11, 0x12, 0x14,
 	}
 
-	layerStreamTypes := ds1.setupStreamLayerTypes()
+	layerStreamTypes := ds1.GetStreamLayerTypes()
 
 	for _, layerStreamType := range layerStreamTypes {
 		for y := 0; y < int(ds1.height); y++ {
@@ -1021,7 +1022,7 @@ func (ds1 *DS1) Marshal() []byte {
 }
 
 func (ds1 *DS1) encodeLayers(sw *d2datautils.StreamWriter) {
-	layerStreamTypes := ds1.setupStreamLayerTypes()
+	layerStreamTypes := ds1.GetStreamLayerTypes()
 
 	for _, layerStreamType := range layerStreamTypes {
 		for y := 0; y < int(ds1.height); y++ {

--- a/d2common/d2fileformats/d2ds1/ds1.go
+++ b/d2common/d2fileformats/d2ds1/ds1.go
@@ -477,8 +477,6 @@ func (ds1 *DS1) update() {
 	}
 
 	ds1.dirty = false
-
-	return
 }
 
 func (ds1 *DS1) ensureAtLeastOneTile() {

--- a/d2common/d2fileformats/d2ds1/ds1_test.go
+++ b/d2common/d2fileformats/d2ds1/ds1_test.go
@@ -489,11 +489,16 @@ func TestDS1_NumberOfWalls(t *testing.T) {
 }
 
 func TestDS1_SetNumberOfWalls(t *testing.T) {
+	var err error
+
 	ds1 := exampleDS1()
 
 	newNumber := int32(4)
 
-	ds1.SetNumberOfWallLayers(newNumber)
+	err = ds1.SetNumberOfWallLayers(newNumber)
+	if err != nil {
+		t.Errorf("error setting number of walls: %v", err)
+	}
 
 	test := func(ds1 *DS1) {
 		if len(ds1.tiles[0][0].Walls) != int(newNumber) {
@@ -505,13 +510,16 @@ func TestDS1_SetNumberOfWalls(t *testing.T) {
 		}
 	}
 
-	if err := testIfRestorable(ds1, test); err != nil {
+	if err = testIfRestorable(ds1, test); err != nil {
 		t.Errorf("unable to restore: %v", err)
 	}
 
 	newNumber = 1
 
-	ds1.SetNumberOfWallLayers(newNumber)
+	err = ds1.SetNumberOfWallLayers(newNumber)
+	if err != nil {
+		t.Errorf("error setting number of walls: %v", err)
+	}
 
 	test = func(ds1 *DS1) {
 		if len(ds1.tiles[0][0].Walls) != int(newNumber) {
@@ -523,7 +531,7 @@ func TestDS1_SetNumberOfWalls(t *testing.T) {
 		}
 	}
 
-	if err := testIfRestorable(ds1, test); err != nil {
+	if err = testIfRestorable(ds1, test); err != nil {
 		t.Errorf("unable to restore: %v", err)
 	}
 }
@@ -537,11 +545,16 @@ func TestDS1_NumberOfFloors(t *testing.T) {
 }
 
 func TestDS1_SetNumberOfFloors(t *testing.T) {
+	var err error
+
 	ds1 := exampleDS1()
 
 	newNumber := int32(2)
 
-	ds1.SetNumberOfFloorLayers(newNumber)
+	err = ds1.SetNumberOfFloorLayers(newNumber)
+	if err != nil {
+		t.Errorf("error setting number of floors: %v", err)
+	}
 
 	test := func(ds1 *DS1) {
 		if len(ds1.tiles[0][0].Floors) != int(newNumber) {
@@ -553,13 +566,16 @@ func TestDS1_SetNumberOfFloors(t *testing.T) {
 		}
 	}
 
-	if err := testIfRestorable(ds1, test); err != nil {
+	if err = testIfRestorable(ds1, test); err != nil {
 		t.Errorf("unable to restore: %v", err)
 	}
 
 	newNumber = 1
 
-	ds1.SetNumberOfFloorLayers(newNumber)
+	err = ds1.SetNumberOfFloorLayers(newNumber)
+	if err != nil {
+		t.Errorf("error setting number of floors: %v", err)
+	}
 
 	test = func(ds1 *DS1) {
 		if len(ds1.tiles[0][0].Floors) != int(newNumber) {
@@ -571,7 +587,7 @@ func TestDS1_SetNumberOfFloors(t *testing.T) {
 		}
 	}
 
-	if err := testIfRestorable(ds1, test); err != nil {
+	if err = testIfRestorable(ds1, test); err != nil {
 		t.Errorf("unable to restore: %v", err)
 	}
 }

--- a/d2common/d2fileformats/d2ds1/ds1_test.go
+++ b/d2common/d2fileformats/d2ds1/ds1_test.go
@@ -640,7 +640,7 @@ func TestDS1_SetSubstitutionGroups(t *testing.T) {
 	}
 }
 
-func TestDS1_setupStreamLayerTypes(t *testing.T) {
+func TestDS1_GetStreamLayerTypes(t *testing.T) {
 	ds1 := exampleDS1()
 
 	lst := []d2enum.LayerStreamType{
@@ -651,7 +651,7 @@ func TestDS1_setupStreamLayerTypes(t *testing.T) {
 		d2enum.LayerStreamSubstitute,
 	}
 
-	layerStreamTypes := ds1.setupStreamLayerTypes()
+	layerStreamTypes := ds1.GetStreamLayerTypes()
 
 	if len(lst) != len(layerStreamTypes) {
 		t.Fatal("unexpected length")

--- a/d2common/d2fileformats/d2ds1/ds1_test.go
+++ b/d2common/d2fileformats/d2ds1/ds1_test.go
@@ -491,7 +491,7 @@ func TestDS1_NumberOfWalls(t *testing.T) {
 func TestDS1_SetNumberOfWalls(t *testing.T) {
 	ds1 := exampleDS1()
 
-	newNumber := int32(3)
+	newNumber := int32(4)
 
 	ds1.SetNumberOfWallLayers(newNumber)
 

--- a/d2common/d2fileformats/d2ds1/ds1_test.go
+++ b/d2common/d2fileformats/d2ds1/ds1_test.go
@@ -56,7 +56,6 @@ func exampleDS1() *DS1 {
 		numberOfFloorLayers:        1,
 		numberOfShadowLayers:       1,
 		numberOfSubstitutionLayers: 1,
-		npcIndexes:                 []int{},
 	}
 }
 
@@ -492,7 +491,7 @@ func TestDS1_NumberOfWalls(t *testing.T) {
 func TestDS1_SetNumberOfWalls(t *testing.T) {
 	ds1 := exampleDS1()
 
-	newNumber := int32(2)
+	newNumber := int32(3)
 
 	ds1.SetNumberOfWallLayers(newNumber)
 


### PR DESCRIPTION
NpcIndexes was unnecessary, because described a number of objects with paths to use in encoder, but we can calculate manually